### PR TITLE
Bypass local proxy urls

### DIFF
--- a/src/Moryx.Cli.Commands/ExecCommand.cs
+++ b/src/Moryx.Cli.Commands/ExecCommand.cs
@@ -1,4 +1,5 @@
 ﻿using Moryx.Cli.Commands.Options;
+using System.Net;
 using System.Net.Http.Json;
 
 namespace Moryx.Cli.Commands
@@ -19,7 +20,10 @@ namespace Moryx.Cli.Commands
 
         internal static CommandResult PostSetup(ExecOptions options)
         {
-            var httpClient = new HttpClient();
+            var httpClient = new HttpClient(new HttpClientHandler
+            {
+                Proxy = new WebProxy { BypassProxyOnLocal = true }
+            });
 
             try
             {


### PR DESCRIPTION
Not bypassing the local proxy urls lead to issues on company networks and accessing the local command center. I added the configuration to bypass local urls - in future it would be better to have a configuration for the whole proxy stuff (with usage of system...)