### PR TITLE
Remove `Moryx.` prefix from product config target types

### DIFF
--- a/src/Moryx.Cli.Commands/AddProducts.cs
+++ b/src/Moryx.Cli.Commands/AddProducts.cs
@@ -90,7 +90,7 @@ namespace Moryx.Cli.Commands
         => new()
         {
             JsonColumn = "Text8",
-            TargetType = $"Moryx.{solutionName}.Products.{product}Type",
+            TargetType = $"{solutionName}.Products.{product}Type",
             PropertyConfigs = new List<PropertyMapperConfig>(),
             PluginName = "GenericTypeStrategy",
         };
@@ -98,7 +98,7 @@ namespace Moryx.Cli.Commands
         private static ProductInstanceConfiguration BuildProductInstanceConfiguration(string solutionName, string product)
         => new()
         {
-            TargetType = $"Moryx.{solutionName}.Products.{product}Instance",
+            TargetType = $"{solutionName}.Products.{product}Instance",
             PluginName = "SkipInstancesStrategy",
         };
     }


### PR DESCRIPTION
Otherwise, config values would mismatch the actual types and result in products which can't be initialized.