### PR TITLE
Upload artifacts first

### DIFF
--- a/.github/workflows/.build-and-publish.yml
+++ b/.github/workflows/.build-and-publish.yml
@@ -89,6 +89,13 @@ jobs:
         run: cp -r artifacts/build artifacts/Licensing
         if: ${{ github.ref_name == 'dev' ||  github.ref_name == 'future' || (startsWith(github.ref, 'refs/tags/v')) }}
 
+      - name: ⬆️ Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: packages
+          path: artifacts/packages/
+        if: ${{ github.ref_name == 'dev' ||  github.ref_name == 'future' || (startsWith(github.ref, 'refs/tags/v')) }}        
+
       - name: 📦 Create Packages and 🚚 deliver to NuGet
         run: |
           .\set-version.ps1 -RefName ${{ github.ref_name }} -IsTag ${{ github.ref_type == 'tag' && 1 || 0 }} -BuildNumber ${{ github.run_number }} -CommitHash ${{ github.sha }}
@@ -103,10 +110,3 @@ jobs:
           .\pack-publish.ps1 -NugetApiKey ${{ secrets.MYGET_TOKEN }} -PackageTarget ${{ needs.Variables.outputs.MORYX_PACKAGE_TARGET }}
         shell: pwsh
         if: ${{ github.ref_name == 'dev' ||  github.ref_name == 'future' }}
-
-      - name: ⬆️ Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: packages
-          path: artifacts/packages/
-        if: ${{ github.ref_name == 'dev' ||  github.ref_name == 'future' || (startsWith(github.ref, 'refs/tags/v')) }}


### PR DESCRIPTION
Artifacts have been uploaded after pushing the packages to feeds. In case the latter didn't work, the build broke and artifacts weren't accessable to push them manually.